### PR TITLE
fix: scale wide Mermaid diagrams to fit the column (stop sidebar overlap)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -535,9 +535,9 @@ body {
 /* Mermaid diagrams: the renderer bakes a hard pixel width/height into the SVG
    (e.g. width="1204") which overflows the column and spills into the sidebar.
    The SVG also carries a viewBox, so clamping to the container width and letting
-   height follow scales the whole diagram down proportionally to fit. overflow-x
-   is a safety net for the rare case a scaled diagram is still wider than the
-   column. */
+   height follow scales the whole diagram down proportionally to fit. The svg
+   max-width is what actually fixes the overflow; overflow-x is a harmless
+   belt-and-suspenders guard (with it clamped, horizontal scroll won't trigger). */
 .mermaid-diagram {
   overflow-x: auto;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -528,8 +528,22 @@ body {
 .prose-article > * {
   max-width: 66ch;
 }
-.prose-article > :is(img, figure, pre, table, hr) {
+.prose-article > :is(img, figure, pre, table, hr, .mermaid-diagram) {
   max-width: 100%;
+}
+
+/* Mermaid diagrams: the renderer bakes a hard pixel width/height into the SVG
+   (e.g. width="1204") which overflows the column and spills into the sidebar.
+   The SVG also carries a viewBox, so clamping to the container width and letting
+   height follow scales the whole diagram down proportionally to fit. overflow-x
+   is a safety net for the rare case a scaled diagram is still wider than the
+   column. */
+.mermaid-diagram {
+  overflow-x: auto;
+}
+.mermaid-diagram svg {
+  max-width: 100%;
+  height: auto;
 }
 
 /* Slides: cap an image (e.g. a baked yoyo illustration) so it sits INSIDE the


### PR DESCRIPTION
## Problem

On [recursive-self-improvement-rsi](https://yopedia.yolog.dev/wiki/recursive-self-improvement-rsi) the RSI flowchart renders far wider than the article column and spills across the **"On this page"** sidebar — nodes like `Improve?` / `Keep Current` land on top of the TOC.

## Cause

The Mermaid renderer (beautiful-mermaid) bakes a **hard pixel width** into the SVG (`width="1204"` for this chart) alongside its `viewBox`. The `<div class="mermaid-diagram">` replaces `<pre>`, so `.prose-article > *` capped the *div* at the 66ch reading measure — but nothing constrained the **SVG inside it**, which rendered at its full 1204px intrinsic width and overflowed.

## Fix (CSS only)

- Add `.mermaid-diagram` to the full-column media list (`img, figure, pre, table, hr`) so a diagram gets the whole column instead of 66ch.
- Clamp the SVG: `max-width:100%; height:auto`. Because the SVG has a `viewBox`, this scales the whole diagram down proportionally to fit the column (CSS `max-width` overrides the presentation `width` attribute; `height:auto` recomputes from the viewBox ratio). Same responsive pattern the `<img>` handler already uses (`MarkdownRenderer.tsx:189`). `overflow-x:auto` is a safety net.

No content change — fixes every wide diagram site-wide, not just this page.

## Test
- `pnpm build` green. CSS-only; no logic/tests affected.
- Behavior is spec-guaranteed for viewBox SVGs; verified the SVG carries `viewBox="0 0 1204.396 200.784"` + hard `width`/`height`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)